### PR TITLE
[bugfix] Use default device in get_engine_list

### DIFF
--- a/QASMConverter/qasm_converter.py
+++ b/QASMConverter/qasm_converter.py
@@ -350,10 +350,10 @@ def _define_args():
             '--ibm',
             '-q',
             default=None,
-            const='ibmqx4',
+            const='ibmq_qasm_simulator',
             metavar='dev',
             nargs='?',
-            help='additionally convert to OpenQASM code that is compatible with the IBM Q Computer `dev` (default: ibmqx4)'
+            help='additionally convert to OpenQASM code that is compatible with the IBM Q Computer `dev` (default: ibmq_qasm_simulator)'
     )
     args.add_argument(
             '--use-hardware',
@@ -426,14 +426,18 @@ def main():
     fin = args.infile
     fout = args.outfile
 
-    engines = ibm.get_engine_list()
-    
+    # by default use IBMQ simulator to generate engines
+    dev = 'ibmq_qasm_simulator'
+
     # remove the CNot flipper
     if not args.ibm:
         engines = engines[:-2] + engines[-1:]
         print('Converting...')
     else:
         print('Converting for IBM Q Experience...')
+        dev = ibm.args
+
+    engines = ibm.get_engine_list(device=dev)
 
     if args.on_hardware:
         print('We will run the converted code on the IBM device {}\n.'.format(args.ibm))


### PR DESCRIPTION
This is a quick fix for the `DeviceOfflineError` that was coming up when using the QASM converter.

However: the real problem (and real solution) would be to not use `projectq` anymore. The package is very outdated and does not seem to support any of the modern IBM QE devices. Supporting this probably is not worth the effort at the moment. For the time being the fix means the converter should be usable for simple usecases at least.

Note that I do not have a Mathematica license at the moment and do not have any example circuit on my machine that I could use to test the converter properly. You should probably try and run a simple
```
python qasm-conv.py example_input out.qasm
```
just to double check this actually works. (Or upload an example file here and I'll test it myself).